### PR TITLE
`lua_Reader` had wrong signature

### DIFF
--- a/source/bindbc/lua/v51/types.d
+++ b/source/bindbc/lua/v51/types.d
@@ -70,7 +70,7 @@ struct lua_State;
 
 extern(C) nothrow {
     alias lua_CFunction = int function(lua_State*);
-    alias lua_Reader = const(char)* function(lua_State*,void*,size_t);
+    alias lua_Reader = const(char)* function(lua_State*,void*,size_t*);
     alias lua_Writer = int function(lua_State*,const(void)*,size_t,void*);
     alias lua_Alloc = void* function(void*,void*,size_t,size_t);
 }

--- a/source/bindbc/lua/v52/types.d
+++ b/source/bindbc/lua/v52/types.d
@@ -77,7 +77,7 @@ struct lua_State;
 
 extern(C) nothrow {
     alias lua_CFunction = int function(lua_State*);
-    alias lua_Reader = const(char)* function(lua_State*,void*,size_t);
+    alias lua_Reader = const(char)* function(lua_State*,void*,size_t*);
     alias lua_Writer = int function(lua_State*,const(void)*,size_t,void*);
     alias lua_Alloc = void* function(void*,void*,size_t,size_t);
 }

--- a/source/bindbc/lua/v53/types.d
+++ b/source/bindbc/lua/v53/types.d
@@ -82,7 +82,7 @@ struct lua_State;
 extern(C) nothrow {
     alias lua_CFunction = int function(lua_State*);
     alias lua_KFunction = int function(lua_State*,int,lua_KContext);
-    alias lua_Reader = const(char)* function(lua_State*,void*,size_t);
+    alias lua_Reader = const(char)* function(lua_State*,void*,size_t*);
     alias lua_Writer = int function(lua_State*,const(void)*,size_t,void*);
     alias lua_Alloc = void* function(void*,void*,size_t,size_t);
 }

--- a/source/bindbc/lua/v54/types.d
+++ b/source/bindbc/lua/v54/types.d
@@ -121,7 +121,7 @@ struct lua_State;
 extern(C) nothrow {
     alias lua_CFunction = int function(lua_State* L);
     alias lua_KFunction = int function(lua_State* L, int status, lua_KContext ctx);
-    alias lua_Reader = const(char)* function(lua_State* L, void* ud, size_t sz);
+    alias lua_Reader = const(char)* function(lua_State* L, void* ud, size_t* sz);
     alias lua_Writer = int function(lua_State* L, const(void)* p, size_t sz, void* ud);
     alias lua_Alloc = void* function(void* ud, void* ptr, size_t osize, size_t nsize);
     alias lua_WarnFunction = void function(void* ud, const(char)* msg, int tocont);


### PR DESCRIPTION
There was a minor issue with how the function pointer type of `lua_Reader` was implemented. I fixed it in all supported versions.